### PR TITLE
fix connection

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,2 @@
+version = "3.7.15"
+runner.dialect = scala3

--- a/SkeletonGameModel.scala
+++ b/SkeletonGameModel.scala
@@ -6,30 +6,26 @@ import io.circe.Decoder
 import io.circe.syntax.*
 import io.circe.parser.decode
 
-
 final case class SkeletonGameModel(
     ourName: String,
     oppoName: String,
     playerNo: Int,
     status: String,
     tx: String,
-    rx:String
+    rx: String
 ) derives Encoder.AsObject,
       Decoder
 object SkeletonGameModel:
-  scribe.debug("@@@ Object SkeletonGameModel Start")
+  // scribe.debug("@@@ Object SkeletonGameModel Start")
 
-  def creation(name1:String, name2:String): SkeletonGameModel =
-    scribe.debug("@@@ SkeletonGameModel creation")
+  def creation(name1: String, name2: String): SkeletonGameModel =
+    // scribe.debug("@@@ SkeletonGameModel creation")
 
-    val pNo = 
-      if (name1.compareTo(name2) > 0) then 
-        2
-      else 
-        1 
+    val pNo =
+      if (name1.compareTo(name2) > 0) then 2
+      else 1
       end if
-    scribe.debug("@@@ Name1:"+name1+ " Name2:" +name2+ "PlayerNo:" +pNo)  
-
+    scribe.debug("@@@ Name1:" + name1 + " Name2:" + name2 + "PlayerNo:" + pNo)
 
     SkeletonGameModel(
       name1,
@@ -40,8 +36,6 @@ object SkeletonGameModel:
       "---"
     )
   end creation
-  scribe.debug("@@@ Object SkeletonGameModel Finish")
+  // scribe.debug("@@@ Object SkeletonGameModel Finish")
 
 end SkeletonGameModel
-
-

--- a/SkeletonGameScene.scala
+++ b/SkeletonGameScene.scala
@@ -4,9 +4,10 @@ import indigo.*
 import indigo.scenes.*
 import org.w3c.dom.css.RGBColor
 
-object SkeletonGameScene extends Scene[StartUpData, SkeletonGameModel, ViewModel]:
+object SkeletonGameScene
+    extends Scene[StartUpData, SkeletonGameModel, ViewModel]:
 
-  type SceneModel     = SkeletonGameModel
+  type SceneModel = SkeletonGameModel
   type SceneViewModel = ViewModel
 
   val name: SceneName =
@@ -26,59 +27,69 @@ object SkeletonGameScene extends Scene[StartUpData, SkeletonGameModel, ViewModel
 
   // For the moment we don't need a timer mechansim
   // val timerDivisor = 100  // makes this timer operate in 10ths of a second ... 0 means disabled, +20 = 2 seconds
-  // var timerT1: Long = (System.currentTimeMillis() / timerDivisor) + 20 
+  // var timerT1: Long = (System.currentTimeMillis() / timerDivisor) + 20
 
   val playerGuideA1 = "You are Player1"
   val playerGuideA2 = "You are Player2"
   val playerGuideB = "P to establish PeerJS"
   val playerGuideC = "ENTER to open connection"
-  val playerGuideD1 = "A,B,C,D,E or F to send ALPHA,BRAVO,CHARLIE,DELTA,ECHO or FOXTROT"
-  val playerGuideD2 = "A,B,C,D,E or F to send alpha,bravo,charlie,delta,echo or foxtrot"
+  val playerGuideD1 =
+    "A,B,C,D,E or F to send ALPHA,BRAVO,CHARLIE,DELTA,ECHO or FOXTROT"
+  val playerGuideD2 =
+    "A,B,C,D,E or F to send alpha,bravo,charlie,delta,echo or foxtrot"
   val playerGuideE = "ESCAPE to close connection"
-
 
   def updateModel(
       context: SceneContext[StartUpData],
       model: SceneModel
   ): GlobalEvent => Outcome[SceneModel] = {
 
-      case e: SkeletonUpdate.Info =>
-        val newStatus = if (e.st.isEmpty()) then model.status else e.st
-        val newTx = if (e.tx.isEmpty()) then model.tx else e.tx
-        val newRx = if (e.rx.isEmpty()) then model.rx else e.rx
-        Outcome(model.copy(status=newStatus, tx=newTx, rx=newRx))
-      
-      case k: KeyboardEvent.KeyDown =>
-        if k.keyCode == Key.KEY_P then Outcome(model).addGlobalEvents(WebRtcEvent.MakePeerEntity)
-        else if k.keyCode == Key.ENTER then Outcome(model).addGlobalEvents(WebRtcEvent.Connect(model.oppoName))
-        else if k.keyCode == Key.ESCAPE then Outcome(model).addGlobalEvents(WebRtcEvent.Close())
-        else
-          val playerNo = model.playerNo
-          val msgToSend1 = (k.keyCode) match
-            case Key.KEY_A => "ALPHA"
-            case Key.KEY_B => "BRAVO"
-            case Key.KEY_C => "CHARLIE"
-            case Key.KEY_D => "DELTA"
-            case Key.KEY_E => "ECHO"
-            case Key.KEY_F => "FOXTROT"
-            case _ => ""
-          if (msgToSend1.isEmpty() == false) then
-            if (playerNo == 1) then
-              Outcome(model).addGlobalEvents(WebRtcEvent.SendGameData(msgToSend1))
-            else
-              val msgToSend2 = msgToSend1.toLowerCase()
-              Outcome(model).addGlobalEvents(WebRtcEvent.SendGameData(msgToSend2))
-          else
-            Outcome(model)
+    case WebRtcEvent.ReceivedData(s: String) =>
+      Outcome(model.copy(status = s))
 
-      case _ =>
-        // For the moment we don't need a timer mechansim
-        //if ((System.currentTimeMillis()/timerDivisor) > timerT1) then
-        //  timerT1 = (System.currentTimeMillis() / timerDivisor) + 20 
-        //  scribe.info("@@@ Timer T1")
-        //end if
-        Outcome(model)
-    }
+    case e: SkeletonUpdate.Info =>
+      val newStatus = if (e.st.isEmpty()) then model.status else e.st
+      val newTx = if (e.tx.isEmpty()) then model.tx else e.tx
+      val newRx = if (e.rx.isEmpty()) then model.rx else e.rx
+      Outcome(model.copy(status = newStatus, tx = newTx, rx = newRx))
+
+    case k: KeyboardEvent.KeyDown =>
+      if k.keyCode == Key.KEY_P then
+        println("Key P")
+        Outcome(model).addGlobalEvents(WebRtcEvent.MakePeerEntity)
+      else if k.keyCode == Key.ENTER then
+        Outcome(model).addGlobalEvents(WebRtcEvent.Connect(model.oppoName))
+      else if k.keyCode == Key.ESCAPE then
+        Outcome(model).addGlobalEvents(WebRtcEvent.Close())
+      else
+        val playerNo = model.playerNo
+        val msgToSend1 = (k.keyCode) match
+          case Key.KEY_A =>
+            println("Key A")
+            "ALPHA"
+          case Key.KEY_B => "BRAVO"
+          case Key.KEY_C => "CHARLIE"
+          case Key.KEY_D => "DELTA"
+          case Key.KEY_E => "ECHO"
+          case Key.KEY_F => "FOXTROT"
+          case _         => ""
+        if (msgToSend1.isEmpty() == false) then
+          if (playerNo == 1) then
+            Outcome(model).addGlobalEvents(WebRtcEvent.SendGameData(msgToSend1))
+          else
+            val msgToSend2 = msgToSend1.toLowerCase()
+            Outcome(model).addGlobalEvents(WebRtcEvent.SendGameData(msgToSend2))
+        else Outcome(model)
+
+    case _ =>
+      // For the moment we don't need a timer mechansim
+      // if ((System.currentTimeMillis()/timerDivisor) > timerT1) then
+      //  timerT1 = (System.currentTimeMillis() / timerDivisor) + 20
+      //  scribe.info("@@@ Timer T1")
+      // end if
+      // scribe.info("no keypress")
+      Outcome(model)
+  }
 //    _ => Outcome(model)
 
   def updateViewModel(
@@ -94,57 +105,106 @@ object SkeletonGameScene extends Scene[StartUpData, SkeletonGameModel, ViewModel
       viewModel: SceneViewModel
   ): Outcome[SceneUpdateFragment] =
 
-    val myColor : RGBA = if (model.playerNo == 1) then RGBA.Cyan else RGBA.Green
-    val oppoColor : RGBA = if (model.playerNo == 1) then RGBA.Green else RGBA.Cyan
-    val playerGuideA = if (model.playerNo == 1) then playerGuideA1 else playerGuideA2
-    val playerGuideD = if (model.playerNo == 1) then playerGuideD1 else playerGuideD2
-          
+    val myColor: RGBA = if (model.playerNo == 1) then RGBA.Cyan else RGBA.Green
+    val oppoColor: RGBA =
+      if (model.playerNo == 1) then RGBA.Green else RGBA.Cyan
+    val playerGuideA =
+      if (model.playerNo == 1) then playerGuideA1 else playerGuideA2
+    val playerGuideD =
+      if (model.playerNo == 1) then playerGuideD1 else playerGuideD2
 
-    val label0A = TextBox(model.ourName,300,80).withColor(myColor).withFontSize(Pixels(40)).moveTo(10,10)
-    val label0B = TextBox("vs",300,80).withColor(myColor).withFontSize(Pixels(40)).moveTo(50,50)
-    val label0C = TextBox(model.oppoName,300,80).withColor(oppoColor).withFontSize(Pixels(40)).moveTo(10,90)
-    val textP1 = TextBox(playerGuideA,400,40).withColor(myColor).withFontSize(Pixels(20)).moveTo(320,10) 
-    val textP2 = TextBox(playerGuideB,400,40).withColor(myColor).withFontSize(Pixels(20)).moveTo(320,40) 
-    val textP3 = TextBox(playerGuideC,400,40).withColor(myColor).withFontSize(Pixels(20)).moveTo(320,70) 
-    val textP4 = TextBox(playerGuideD,800,40).withColor(myColor).withFontSize(Pixels(20)).moveTo(320,100) 
-    val textP5 = TextBox(playerGuideE,400,40).withColor(myColor).withFontSize(Pixels(20)).moveTo(320,130) 
-  
-    val label1 = TextBox("Status:",100,40).withColor(myColor).withFontSize(Pixels(20)).moveTo(10,180)
-    val box1 = Rectangle(Point(5,210), Size(300,50))
-    val text1 = TextBox(model.status,300,40).withColor(RGBA.Black).withFontSize(Pixels(20)).moveTo(10,220)
+    val label0A = TextBox(model.ourName, 300, 80)
+      .withColor(myColor)
+      .withFontSize(Pixels(40))
+      .moveTo(10, 10)
+    val label0B = TextBox("vs", 300, 80)
+      .withColor(myColor)
+      .withFontSize(Pixels(40))
+      .moveTo(50, 50)
+    val label0C = TextBox(model.oppoName, 300, 80)
+      .withColor(oppoColor)
+      .withFontSize(Pixels(40))
+      .moveTo(10, 90)
+    val textP1 = TextBox(playerGuideA, 400, 40)
+      .withColor(myColor)
+      .withFontSize(Pixels(20))
+      .moveTo(320, 10)
+    val textP2 = TextBox(playerGuideB, 400, 40)
+      .withColor(myColor)
+      .withFontSize(Pixels(20))
+      .moveTo(320, 40)
+    val textP3 = TextBox(playerGuideC, 400, 40)
+      .withColor(myColor)
+      .withFontSize(Pixels(20))
+      .moveTo(320, 70)
+    val textP4 = TextBox(playerGuideD, 800, 40)
+      .withColor(myColor)
+      .withFontSize(Pixels(20))
+      .moveTo(320, 100)
+    val textP5 = TextBox(playerGuideE, 400, 40)
+      .withColor(myColor)
+      .withFontSize(Pixels(20))
+      .moveTo(320, 130)
 
-    val label2 = TextBox("TX:",100,40).withColor(myColor).withFontSize(Pixels(20)).moveTo(10,290)      
-    val box2 = Rectangle(Point(5,320), Size(300,50))
-    val text2 = TextBox(model.tx,300,40).withColor(RGBA.Black).withFontSize(Pixels(20)).moveTo(10,330)      
+    val label1 = TextBox("Status:", 100, 40)
+      .withColor(myColor)
+      .withFontSize(Pixels(20))
+      .moveTo(10, 180)
+    val box1 = Rectangle(Point(5, 210), Size(300, 50))
+    val text1 = TextBox(model.status, 300, 40)
+      .withColor(RGBA.Black)
+      .withFontSize(Pixels(20))
+      .moveTo(10, 220)
 
-    val label3 = TextBox("RX:",100,40).withColor(myColor).withFontSize(Pixels(20)).moveTo(10,400)
-    val box3 = Rectangle(Point(5,430), Size(300,50))
-    val text3 = TextBox(model.rx,300,40).withColor(RGBA.Black).withFontSize(Pixels(20)).moveTo(10,440)
+    val label2 = TextBox("TX:", 100, 40)
+      .withColor(myColor)
+      .withFontSize(Pixels(20))
+      .moveTo(10, 290)
+    val box2 = Rectangle(Point(5, 320), Size(300, 50))
+    val text2 = TextBox(model.tx, 300, 40)
+      .withColor(RGBA.Black)
+      .withFontSize(Pixels(20))
+      .moveTo(10, 330)
 
-    val spinner = Shape.Box(Rectangle(0, 0, 60, 60), Fill.LinearGradient(Point(0), RGBA.Magenta, Point(45), RGBA.Cyan))
-          .withRef(30, 30).moveTo(650, 50).rotateTo(Radians.fromSeconds(context.running * 0.25))
+    val label3 = TextBox("RX:", 100, 40)
+      .withColor(myColor)
+      .withFontSize(Pixels(20))
+      .moveTo(10, 400)
+    val box3 = Rectangle(Point(5, 430), Size(300, 50))
+    val text3 = TextBox(model.rx, 300, 40)
+      .withColor(RGBA.Black)
+      .withFontSize(Pixels(20))
+      .moveTo(10, 440)
 
+    val spinner = Shape
+      .Box(
+        Rectangle(0, 0, 60, 60),
+        Fill.LinearGradient(Point(0), RGBA.Magenta, Point(45), RGBA.Cyan)
+      )
+      .withRef(30, 30)
+      .moveTo(650, 50)
+      .rotateTo(Radians.fromSeconds(context.running * 0.25))
 
     Outcome(
       SceneUpdateFragment.empty
-      |+| SceneUpdateFragment(label0A)
-      |+| SceneUpdateFragment(label0B)
-      |+| SceneUpdateFragment(label0C)
-      |+| SceneUpdateFragment(textP1)
-      |+| SceneUpdateFragment(textP2)
-      |+| SceneUpdateFragment(textP3)
-      |+| SceneUpdateFragment(textP4)
-      |+| SceneUpdateFragment(textP5)
-      |+| SceneUpdateFragment(spinner)
-      |+| SceneUpdateFragment(label1)
-      |+| SceneUpdateFragment(Shape.Box(box1, Fill.Color(RGBA.White)))
-      |+| SceneUpdateFragment(text1)
-      |+| SceneUpdateFragment(label2)
-      |+| SceneUpdateFragment(Shape.Box(box2, Fill.Color(RGBA.White)))
-      |+| SceneUpdateFragment(text2)
-      |+| SceneUpdateFragment(label3)
-      |+| SceneUpdateFragment(Shape.Box(box3, Fill.Color(RGBA.White)))
-      |+| SceneUpdateFragment(text3)
+        |+| SceneUpdateFragment(label0A)
+        |+| SceneUpdateFragment(label0B)
+        |+| SceneUpdateFragment(label0C)
+        |+| SceneUpdateFragment(textP1)
+        |+| SceneUpdateFragment(textP2)
+        |+| SceneUpdateFragment(textP3)
+        |+| SceneUpdateFragment(textP4)
+        |+| SceneUpdateFragment(textP5)
+        |+| SceneUpdateFragment(spinner)
+        |+| SceneUpdateFragment(label1)
+        |+| SceneUpdateFragment(Shape.Box(box1, Fill.Color(RGBA.White)))
+        |+| SceneUpdateFragment(text1)
+        |+| SceneUpdateFragment(label2)
+        |+| SceneUpdateFragment(Shape.Box(box2, Fill.Color(RGBA.White)))
+        |+| SceneUpdateFragment(text2)
+        |+| SceneUpdateFragment(label3)
+        |+| SceneUpdateFragment(Shape.Box(box3, Fill.Color(RGBA.White)))
+        |+| SceneUpdateFragment(text3)
     )
 
 object SkeletonUpdate:

--- a/SkeletonGameScene.scala
+++ b/SkeletonGameScene.scala
@@ -45,6 +45,7 @@ object SkeletonGameScene
   ): GlobalEvent => Outcome[SceneModel] = {
 
     case WebRtcEvent.ReceivedData(s: String) =>
+      scribe.info("ReceivedData")
       Outcome(model.copy(status = s))
 
     case e: SkeletonUpdate.Info =>

--- a/project.scala
+++ b/project.scala
@@ -1,6 +1,6 @@
-//> using scala 3.5.2
+//> using scala 3.6.1
 //> using platform js
-//> using jsVersion 1.16.0
+//> using jsVersion 1.17.0
 
 //> using jsModuleKind es
 //> using jsModuleSplitStyleStr smallmodulesfor


### PR DESCRIPTION
Soo... I figured it out in the end. And in fairness it was awkward and probably my fault. 

Basically, we were only ever setting the _outwards_ connection. The two peers would connect successfully, and we correctly set the `DataConnection` of the _outwards_ (sending) client. 

Client A says "hi wanna talk". 
B say "great" 
A sets it's connection details and sends the connection details back to B
B gets connection details from A and discards them, keeping its own "outbound" connection instead. 

Instead of that, B now emits the incoming connection as an event, and we use that event to set the active data connection between the two.

I also reworked the event system, so that pretty much everything now works through indigos event loop, you should be able to see what I've missed quite easily. Also, emitting events in a queue so none are dropped. 

Also, note that error handling is _very_ important. Peer names are not recycled instantly, so if you try to quickly connect again as "simon", peer JS will refuse you. I think sometimes it's slow and that can create race conditions . I strongly recommend logging those as "scribe.error" as then they'll go red in the browser console and you'll see them quickly. user probably needs to know about them as well. 

